### PR TITLE
This commit enhances the promo-agent to send notifications to a Slack…

### DIFF
--- a/src/promo-agent/app.py
+++ b/src/promo-agent/app.py
@@ -12,6 +12,12 @@ CATALOG_READER_URL = os.environ.get("CATALOG_READER_URL")
 if not CATALOG_READER_URL:
     raise RuntimeError("CATALOG_READER_URL environment variable not set.")
 
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+if SLACK_WEBHOOK_URL:
+    print("Slack webhook URL found. Notifications will be sent to Slack.")
+else:
+    print("SLACK_WEBHOOK_URL not set. Price drop alerts will only be logged to the console.")
+
 # In a real application, this would be stored in a persistent database (e.g., Redis, Firestore)
 # We are using a simple in-memory dictionary for this demo.
 # The key is the product_id, the value is the last known price.
@@ -21,10 +27,23 @@ WATCHED_PRODUCTS = {
     "1YMWWN1N4O": None,  # Kids Tee
 }
 
+def send_slack_notification(message: str):
+    """Sends a message to the configured Slack webhook."""
+    if not SLACK_WEBHOOK_URL:
+        return # Do nothing if the webhook is not configured
+
+    try:
+        payload = {'text': message}
+        response = requests.post(SLACK_WEBHOOK_URL, json=payload)
+        response.raise_for_status()
+        print("Successfully sent notification to Slack.")
+    except requests.exceptions.RequestException as e:
+        print(f"Error sending Slack notification: {e}")
+
 def check_product_prices():
     """
     Checks the prices of products in the WATCHED_PRODUCTS list.
-    If a price has dropped, it prints a notification.
+    If a price has dropped, it prints a notification and sends it to Slack.
     """
     print("--- Checking for price drops... ---")
     for product_id, last_price in WATCHED_PRODUCTS.items():
@@ -36,20 +55,23 @@ def check_product_prices():
             product_data = response.json()
 
             # Extract the current price
-            # The price is in the 'priceUsd' object under the 'units' key
             current_price_str = product_data.get('priceUsd', {}).get('units', '0')
             current_price = int(current_price_str)
+            product_name = product_data.get('name', 'Unknown Product')
 
-            print(f"Checking product: {product_data.get('name')} ({product_id}). Current price: ${current_price}")
+            print(f"Checking product: {product_name} ({product_id}). Current price: ${current_price}")
 
-            if last_price is not None:
-                # If we have a last known price, check for a drop
-                if current_price < last_price:
-                    print("="*50)
-                    print(f"🎉 PRICE DROP ALERT! 🎉")
-                    print(f"Product: {product_data.get('name')} ({product_id})")
-                    print(f"Old Price: ${last_price}, New Price: ${current_price}")
-                    print("="*50)
+            if last_price is not None and current_price < last_price:
+                # Price has dropped
+                message = (
+                    f"🎉 PRICE DROP ALERT! 🎉\n"
+                    f"Product: {product_name} ({product_id})\n"
+                    f"Old Price: ${last_price}, New Price: ${current_price}"
+                )
+                print("="*50)
+                print(message)
+                print("="*50)
+                send_slack_notification(message)
 
             # Update the last known price with the current price
             WATCHED_PRODUCTS[product_id] = current_price


### PR DESCRIPTION
… webhook when a price drop is detected.

The agent now reads a SLACK_WEBHOOK_URL from its environment. If the URL is present, it will format a message with the product details and the price change, and send it to the specified Slack channel.

If the webhook URL is not configured, the agent will gracefully fall back to only logging the price drop alert to the console. This ensures the service remains functional without a Slack integration.

### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
